### PR TITLE
Commanding Officer's Desert Eagle

### DIFF
--- a/belts.yml
+++ b/belts.yml
@@ -1,0 +1,1050 @@
+# Simple
+- type: entity
+  parent: ClothingBeltBase
+  id: CMBeltInflatable
+  name: inflatable duck
+  description: No bother to sink or swim when you can just float!
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/inflatable.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/inflatable.rsi
+
+# Storage
+- type: entity
+  parent: CMBeltBaseStorage
+  id: CMBeltMarine
+  name: M276 pattern ammo load rig
+  description: The M276 is the standard load-bearing equipment of the UNMC. It consists of a modular belt with various clips. This is the standard variant, designed for bulk ammunition-carrying operations.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/marine.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/marine.rsi
+  - type: Item
+    size: Large
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,9,1 # 5 slots
+    whitelist:
+      tags:
+      - Flare
+      - RMCShellShotgun
+      - CMMagazinePistol
+      - RMCMagazineRevolver
+      - CMMagazineRifle
+      - CMMagazineSmg
+      - CMMagazineSniper
+      - Grenade
+#      - # TODO RMC14 mines
+#      - # TODO RMC14 snacks
+      components:
+      - BallisticAmmoProvider
+  - type: IgnoreContentsSize
+    items:
+      tags:
+      - CMMagazineRifle
+      - CMMagazineSmg
+  - type: FixedItemSizeStorage
+
+- type: entity
+  parent: CMBeltBaseStorage
+  id: RMCM276ShotgunShellLoadingRig
+  name: M276 pattern shotgun shell loading rig
+  description: An ammunition belt designed to hold shotgun shells. # or individual bullets. TODO RMC14
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/shotgun.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/shotgun.rsi
+  - type: Item
+    size: Large
+  - type: Storage
+    maxItemSize: Large
+    grid:
+    - 0,0,13,3 # 14 slots
+    whitelist:
+      tags:
+      - RMCShellShotgun
+      - RMCCartridge458SOCOM
+  - type: IgnoreContentsSize
+    items:
+      tags:
+      - CMMagazineRifle
+      - CMMagazineSmg
+  - type: FixedItemSizeStorage
+
+- type: entity
+  parent: CMBeltBaseStorage
+  id: CMBeltUtility
+  name: M276 pattern toolbelt rig
+  description: The M276 is the standard load-bearing equipment of the UNMC. It consists of a modular belt with various clips. This version lacks any combat functionality, and is commonly used by engineers to transport important tools.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/utility.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/utility.rsi
+  - type: Storage
+    maxItemSize: Large
+    grid:
+    - 0,0,19,1 # 10 slots
+    whitelist:
+      tags:
+      - Crowbar
+      - Screwdriver
+      - Wirecutter
+      - Wrench
+      - CableCoil
+      - Multitool
+      - Flashlight
+      - PowerCell
+      - CMFireExtinguisherPortable
+      - RMCExplosiveBreachingCharge
+#      - # TODO nailgun, circuit board
+      components:
+      - Welder
+      - PowerCell
+      - TrayScanner
+      - GasAnalyzer
+      - LightReplacer
+      - EntrenchingTool
+  - type: IgnoreContentsSize
+    items:
+      components:
+      - EntrenchingTool
+      - LightReplacer
+  - type: FixedItemSizeStorage
+
+- type: entity
+  parent: CMBeltUtility
+  id: RMCBeltConstruction
+  name: M277 pattern construction rig
+  description: The M277 is a common rig used by Combat Technicians to carry around materials and other supplies. It consists of a modular belt with various clips. This version sacrifices storage space for specialized material loading clips.
+  components:
+  - type: Storage
+    grid:
+    - 0,0,11,1 # 6 slots
+    whitelist:
+      tags:
+      - Crowbar
+      - Screwdriver
+      - Wirecutter
+      - Wrench
+      - CableCoil
+      - Multitool
+      - Flashlight
+      - PowerCell
+      - CMFireExtinguisherPortable
+      - RMCExplosiveBreachingCharge
+#     - # TODO nailgun, circuit board, plastic explosives, stock parts
+      components:
+      - Welder
+      - PowerCell
+      - TrayScanner
+      - GasAnalyzer
+      - LightReplacer
+      - EntrenchingTool
+      - BarbedWire
+      - Material
+      - Sentry
+      - EmptySandbag
+      - FullSandbag
+  - type: IgnoreContentsSize
+    items:
+      components:
+      - EntrenchingTool
+      - LightReplacer
+      - Material
+      - Sentry
+      - FullSandbag
+
+- type: entity
+  parent: CMBeltUtility
+  id: CMBeltUtilityCombat
+  name: M276 pattern combat toolbelt rig
+  description: The M276 pattern combat toolbelt rig is an alternative load-bearing equipment of the UNMC for engineers conducting repairs within combat zones. It consists of a modular belt with various clips and pouches for tools along with a holster for a sidearm. Due to the bulk of the sidearm, it is unable to hold as many tools as its standard counterpart.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/combat_utility.rsi
+    layers:
+    - state: icon
+    - sprite: _RMC14/Objects/Weapons/Guns/gun_underlays.rsi
+      state: m1984 # TODO RMC14 per-gun underlay
+      offset: -0.3125, -0.09375
+      map: [ "enum.CMHolsterLayers.Fill" ]
+      visible: false
+    - state: icon-front
+    - state: half
+      map: [ "openLayer" ]
+    - state: full
+      map: [ "closedLayer" ]
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/combat_utility.rsi
+  - type: Storage
+    maxItemSize: Large
+    grid:
+    - 0,0,17,1 # 9 slots
+    whitelist:
+      tags:
+      - Crowbar
+      - Screwdriver
+      - Wirecutter
+      - Wrench
+      - CableCoil
+      - Multitool
+      - Flashlight
+      - Sidearm
+      - CMMagazinePistol
+      - RMCMagazineRevolver
+      - PowerCell
+      - CMFireExtinguisherPortable
+      - RMCShellShotgun
+#      - # TODO nailgun, circuit board
+      components:
+      - Welder
+      - PowerCell
+      - TrayScanner
+      - GasAnalyzer
+      - LightReplacer
+      - EntrenchingTool
+  - type: FixedItemSizeStorage
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-one-gun
+      whitelist:
+        components:
+        - Gun
+  - type: CMHolster
+    whitelist:
+      components:
+      - Gun
+
+- type: entity
+  parent: CMBeltBase
+  id: CMBeltKnife
+  name: M276 pattern knife rig
+  description: The M276 is the standard load-bearing equipment of the UNMC. It consists of a modular belt with various clips. This version is specially designed to store knives. Not commonly issued, but kept in service.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/knife.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/knife.rsi
+  - type: ItemSlots
+  - type: CMHolster
+  - type: UsableWhileDevoured
+  - type: CMItemSlots
+    cooldown: 1
+    cooldownPopup: You need to wait before drawing another knife!
+    count: 12
+    slot:
+      name: Knife
+      whitelist:
+        tags:
+        - ThrowingKnife
+
+- type: entity
+  parent: CMBeltBaseStorage
+  id: CMBeltMedical
+  name: M276 pattern medical storage rig
+  description: The M276 is the standard load-bearing equipment of the UNMC. It consists of a modular belt with various clips. This version is a less common configuration, designed to transport bulkier medical supplies.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/medical.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/medical.rsi
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,13,3 # 14 slots
+    whitelist:
+      tags:
+      - DiscreteHealthAnalyzer
+      # dropper
+      - GlassBeaker
+      - Bottle
+      - PillCanister
+      - Syringe
+      - CMSurgicalLine
+      - CMSynthGraft
+      - Brutepack
+      - CMBloodPack
+      - Gauze
+      - Ointment
+      - CMOintment
+      - CMTraumaKit
+      - CMBurnKit
+#      - # TODO RMC14 splints
+      - CMAutoInjector
+      - CMRollerBed
+      - BodyBag
+#      - # TODO RMC14 latex gloves
+      - Hypospray
+      components:
+      - Hypospray
+      - Defibrillator
+      - Pill
+  - type: FixedItemSizeStorage
+
+- type: entity
+  parent: CMBeltMedical
+  id: CMBeltMedicBag
+  name: M276 pattern lifesaver bag
+  description: The M276 is the standard load-bearing equipment of the UNMC. This configuration mounts a duffel bag filled with a range of injectors and light medical supplies, and is common among medics.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/medicbag.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/medicbag.rsi
+  - type: Storage
+    maxItemSize: Small
+    grid:
+    - 0,0,13,5 # 21 slots
+    whitelist:
+      tags:
+      - DiscreteHealthAnalyzer
+      - BodyBag
+      - Bottle
+      - PillCanister
+      - Syringe
+      - CMAutoInjector
+      - Brutepack
+      - CMBloodPack
+      - Gauze
+      - Ointment
+      - CMOintment
+      - CMTraumaKit
+      - CMBurnKit
+      #      - # TODO RMC14 splints
+      - RMCGlovesLatex
+      components:
+      - Defibrillator
+      - Pill
+  - type: FixedItemSizeStorage
+  - type: IgnoreContentsSize
+    items:
+      tags:
+      - PillCanister
+
+- type: entity
+  parent: CMBeltBaseStorage
+  id: CMBeltMortar
+  name: M276 pattern mortar operator belt
+  description: An M276 load-bearing rig configured to carry ammunition for the M402 mortar, along with a sidearm.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/mortar.rsi
+    layers:
+    - sprite: _RMC14/Objects/Weapons/Guns/gun_underlays.rsi
+      state: m1984 # TODO RMC14 per-gun underlay
+      offset: 0.375, 0
+      map: [ "enum.CMHolsterLayers.Fill" ]
+      visible: false
+    - state: icon
+    - state: half
+      map: [ "openLayer" ]
+    - state: full
+      map: [ "closedLayer" ]
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/mortar.rsi
+  - type: Storage
+    maxItemSize: Huge
+    whitelist:
+      components:
+      - MortarShell
+      tags:
+      - Sidearm
+#      - # TODO RMC14 pistol, revolver, flaregun
+  - type: FixedItemSizeStorage
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-one-gun
+      whitelist:
+        components:
+        - Gun
+    - popup: rmc-storage-limit-max-shells
+      count: 6
+      whitelist:
+        components:
+        - MortarShell
+  - type: CMHolster
+    whitelist:
+      components:
+      - Gun
+
+- type: entity
+  parent: CMBeltMarine
+  id: CMBeltSmartGunOperator
+  name: M280 pattern smart gun operator drum belt
+  description: Despite the fact that 1. drum magazines are incredibly non-ergonomical, and 2. require incredibly precise machining in order to fit universally (spoiler, they don't, adding further to the myth of 'Smart Gun Personalities'), the Marines decided to issue a modified marine belt (more formally known by the designation M280) with hooks and dust covers (overly complex for the average jarhead) for the ML66A system's drum munitions. When the carry catch on the drum isn't getting stuck in the oiled up velcro, the rig actually does do a decent job at holding a plentiful amount of drums. But at the end of the day, compared to standard rigs... it sucks, but isn't that what being a Marine is all about?
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/smart_gun_operator.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/smart_gun_operator.rsi
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,11,1 # 6 slots
+    whitelist:
+      tags:
+      - CMMagazinePistol
+      - CMMagazineRifle
+      - CMMagazineSmg
+      - CMMagazineSniper
+      - RMCMagazineSmartGun
+      - RMCShellShotgun
+      - Flare
+  - type: FixedItemSizeStorage
+  - type: IgnoreContentsSize
+    items:
+      tags:
+      - RMCMagazineSmartGun
+
+- type: entity
+  parent: CMBeltMarine
+  id: RMCBeltSmartGunOperatorPistol
+  name: M802 pattern smart gun operator sidearm rig
+  description: The M802 is a limited-issue mark of UNMC load-bearing equipment, designed to carry smartgun ammunition and a sidearm.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/smart_gun_operator_pistol.rsi
+    layers:
+    - state: icon
+    - sprite: _RMC14/Objects/Weapons/Guns/gun_underlays.rsi
+      state: m1984 # TODO RMC14 per-gun underlay
+      offset: 0.15625, 0.0
+      map: [ "enum.CMHolsterLayers.Fill" ]
+      visible: false
+    - state: icon-front
+    - state: half
+      map: [ "openLayer" ]
+    - state: full
+      map: [ "closedLayer" ]
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/smart_gun_operator_pistol.rsi
+  - type: Storage   # Holds up to 4 drums/magazines and 1 sidearm
+    maxItemSize: Normal
+    grid:
+    - 0,0,9,1 # 5 slots
+    whitelist:
+      tags:
+      - Sidearm
+      - CMMagazinePistol
+      - RMCMagazineRevolver
+      - RMCMagazineSmartGun
+      # TODO: flare gun
+      - Flare
+  - type: FixedItemSizeStorage
+  - type: IgnoreContentsSize
+    items:
+      tags:
+      - RMCMagazineSmartGun
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-one-gun
+      whitelist:
+        tags:
+        - Sidearm
+    - popup: rmc-storage-limit-max-ammo
+      count: 4
+      whitelist:
+        tags:
+        - CMMagazinePistol
+        - RMCMagazineRevolver
+        - RMCMagazineSmartGun
+  - type: CMHolster
+    whitelist:
+      tags:
+      - Sidearm
+  - type: Tag
+    tags:
+    - RMCSmartGunSidearmHolster
+
+- type: Tag
+  id: RMCSmartGunSidearmHolster
+
+- type: entity
+  parent: CMBeltMarine
+  id: RMCBeltGrenade
+  name: M276 pattern M40 grenade rig
+  description: The M276 is the standard load-bearing equipment of the UNMC. It consists of a modular belt with various clips. This version is designed to carry up to 12 of the M40 series of grenades.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/grenade.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/grenade.rsi
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,11,3 # 12 slots
+    whitelist:
+      tags:
+      - Grenade
+  - type: FixedItemSizeStorage
+
+- type: entity
+  parent: RMCBeltGrenade
+  id: RMCBeltGrenadeLarge
+  name: M276 pattern M40 grenade rig Mk. II
+  description: The M276 Mk. II is an upgraded version of the M276 grenade rig, with more storage capacity.
+  components:
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,11,5 # 18 slots for now. If future large grenades are introduced this should be increased to be able to hold at least 18 of any grenade.
+    whitelist:
+      tags:
+      - Grenade
+  - type: FixedItemSizeStorage
+
+- type: entity
+  parent: CMBeltMarine
+  id: RMCBeltSmartPistol
+  name: M276 pattern SU-6 smart pistol holster rig
+  description: The M276 is the standard load-bearing equipment of the UNMC. It consists of a modular belt with various clips. This version is for the SU-6 smartpistol.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/smart_pistol.rsi
+    layers:
+    - state: icon
+    - sprite: _RMC14/Objects/Weapons/Guns/gun_underlays.rsi
+      state: smartpistol
+      offset: -0.1875, 0.0
+      map: [ "enum.CMHolsterLayers.Fill" ]
+      visible: false
+    - state: icon-front
+    - state: half
+      map: [ "openLayer" ]
+    - state: full
+      map: [ "closedLayer" ]
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/smart_pistol.rsi
+    slots:
+    - suitStorage
+    - belt
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,13,1 # 7 slots
+    whitelist:
+      tags:
+      - RMCSmartPistol
+      - RMCMagazinePistolSU6
+  - type: FixedItemSizeStorage
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-one-gun
+      whitelist:
+        tags:
+        - RMCSmartPistol
+    - popup: rmc-storage-limit-max-mags
+      count: 6
+      whitelist:
+        tags:
+        - RMCMagazinePistolSU6
+  - type: CMHolster
+    whitelist:
+      tags:
+      - RMCSmartPistol
+  - type: Tag
+    tags:
+    - RMCSmartPistolHolster
+
+- type: Tag
+  id: RMCSmartPistolHolster
+
+- type: entity
+  parent: CMBeltMarine
+  id: RMCBeltHolsterPistol
+  name: M276 pattern general pistol holster rig
+  description: The M276 is the standard load-bearing equipment of the UNMC. It consists of a modular belt with various clips. This version has a holster assembly that allows one to carry the most common pistols. It also contains side pouches that can store most pistol magazines.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/holster_pistol.rsi
+    layers:
+    - state: icon
+    - sprite: _RMC14/Objects/Weapons/Guns/gun_underlays.rsi
+      state: m1984 # TODO RMC14 per-gun underlay
+      map: [ "enum.CMHolsterLayers.Fill" ]
+      visible: false
+    - state: icon-front
+    - state: half
+      map: [ "openLayer" ]
+    - state: full
+      map: [ "closedLayer" ]
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/holster_pistol.rsi
+    slots:
+    - suitStorage
+    - belt
+  - type: Storage # holds up to 6 mags plus gun
+    maxItemSize: Normal
+    grid:
+    - 0,0,13,1 # 7 slots
+    whitelist:
+      tags:
+      - Sidearm
+      - CMMagazinePistol
+    blacklist:
+      tags:
+      - RMCSmartPistol
+      - RMCMagazinePistolSU6
+      - RMCRevolver
+  - type: FixedItemSizeStorage
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-one-gun
+      whitelist:
+        tags:
+        - Sidearm
+    - popup: rmc-storage-limit-max-mags
+      count: 6
+      whitelist:
+        tags:
+        - CMMagazinePistol
+  - type: CMHolster
+    whitelist:
+      tags:
+      - Sidearm
+  - type: Tag
+    tags:
+    - RMCGeneralPistolHolster
+
+- type: Tag
+  id: RMCGeneralPistolHolster
+
+- type: entity
+  parent: CMBeltMarine
+  id: RMCBeltHolsterRevolver
+  name: M276 pattern general revolver holster rig
+  description: he M276 is the standard load-bearing equipment of the UNMC. It consists of a modular belt with various clips. This version is universal and adjustable for different revolvers, along with six small pouches for speedloaders. It smells faintly of hay.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/holster_revolver.rsi
+    layers:
+    - state: icon
+    - sprite: _RMC14/Objects/Weapons/Guns/gun_underlays.rsi
+      state: m44r # TODO RMC14 per-gun underlay
+      map: [ "enum.CMHolsterLayers.Fill" ]
+      visible: false
+    - state: icon-front
+    - state: half
+      map: [ "openLayer" ]
+    - state: full
+      map: [ "closedLayer" ]
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/holster_revolver.rsi
+    slots:
+    - suitStorage
+    - belt
+  - type: Storage # holds up to 6 mags plus gun
+    maxItemSize: Normal
+    grid:
+    - 0,0,13,1 # 7 slots
+    whitelist:
+      tags:
+      - RMCRevolver
+      - RMCMagazineRevolver
+  - type: FixedItemSizeStorage
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-one-gun
+      whitelist:
+        tags:
+        - RMCRevolver
+    - popup: rmc-storage-limit-max-loaders
+      count: 6
+      whitelist:
+        tags:
+        - RMCMagazineRevolver
+  - type: CMHolster
+    whitelist:
+      tags:
+      - RMCRevolver
+  - type: Tag
+    tags:
+    - RMCGeneralRevolverHolster
+
+- type: Tag
+  id: RMCGeneralRevolverHolster
+
+- type: entity
+  parent: ClothingBeltBase # Can't have storage slots on this one
+  id: RMCBeltHolsterSMG
+  name: M276 pattern M63 holster rig
+  description: Special issue variant of the M276 designed to holster a M63 submachine gun.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/holster_smg.rsi
+    layers:
+    - state: icon
+    - sprite: _RMC14/Objects/Weapons/Guns/gun_underlays.rsi
+      state: m63
+      map: [ "enum.CMItemSlotsLayers.Fill" ] # This one's fine to use the CMItemSlots visualizer
+      visible: false
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/holster_smg.rsi
+    slots:
+    - suitStorage
+    - belt
+  - type: ContainerContainer
+    containers:
+      pouch: !type:ContainerSlot
+  - type: ItemSlots
+    slots:
+      pouch:
+        name: M63 holster
+        insertSound: /Audio/_RMC14/Weapons/Guns/gun_pistol_sheathe.ogg # TODO RMC14 sounds
+        ejectSound: /Audio/_RMC14/Weapons/Guns/gun_pistol_draw.ogg
+        whitelist:
+          tags:
+          - RMCWeaponSMGM63
+  - type: CMHolster
+    whitelist:
+      tags:
+      - RMCWeaponSMGM63
+  - type: CMItemSlots
+  - type: Tag
+    tags:
+    - RMCSMGHolster
+
+- type: Tag
+  id: RMCSMGHolster
+
+- type: entity
+  parent: CMBeltBaseStorage
+  id: RMCBeltUtilityGeneral
+  name: M276 G8-A general utility pouch
+  description: A small, lightweight pouch that can be clipped onto M3 Pattern armor to provide additional storage. The newer G8-A model, while uncomfortable, can also be clipped around the waist.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/sparepouch.rsi
+  - type: Clothing
+    slots:
+    - suitStorage
+    - belt
+    sprite: _RMC14/Objects/Clothing/Belt/sparepouch.rsi
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,9,1 # 9 slots
+    blacklist:
+      tags:
+      - CMFirstAidKit # TODO RMC14
+  #      - EngineerKit # TODO RMC14
+  - type: Tag
+    tags:
+    - RMCG8Pouch
+
+- type: Tag
+  id: RMCG8Pouch
+
+- type: entity
+  parent: CMBeltBaseStorage
+  id: RMCBeltHolsterSMGPouch
+  name: M276 pattern M63 holster rig
+  description: Special issue variant of the M276 designed to holster a M63 submachine gun and two spare magazines. Uncommonly issued to UNMC support and specialist personnel.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/smg_mags.rsi
+    layers:
+    - state: icon
+    - sprite: _RMC14/Objects/Weapons/Guns/gun_underlays.rsi
+      state: m63
+      offset: -0.34375, 0.0
+      map: [ "enum.CMHolsterLayers.Fill" ]
+      visible: false
+    - state: weapon
+    - state: half
+      map: [ "openLayer" ]
+    - state: full
+      map: [ "closedLayer" ]
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/smg_mags.rsi
+    slots:
+    - suitStorage
+    - belt
+  - type: Item
+    size: Large
+  - type: Storage
+    maxItemSize: Huge
+    grid:
+    - 0,0,5,1 # 3 slots
+    whitelist:
+      tags:
+      - RMCWeaponSMGM63
+      - CMMagazineSmg
+  - type: FixedItemSizeStorage
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-one-gun
+      whitelist:
+        components:
+        - Gun
+    - popup: rmc-storage-limit-two-mags
+      count: 2
+      whitelist:
+        tags:
+        - CMMagazineSmg
+  - type: CMHolster
+    whitelist:
+      components:
+      - Gun
+  - type: Tag
+    tags:
+    - RMCSMGPouchHolster
+
+- type: Tag
+  id: RMCSMGPouchHolster
+
+- type: entity
+  parent: CMBeltBaseStorage
+  id: RMCMatebaBelt
+  name: M276 pattern Mateba holster rig
+  description: The M276 is the standard load-bearing equipment of the UNMC. It consists of a modular belt with various clips. This version is for the powerful Mateba magnum revolver, along with five small pouches for speedloaders. It was included with the mail-order UNMC edition of the Mateba autorevolver in the early 2170s.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/mateba_belt.rsi
+    layers:
+    - state: cmateba
+      map: [ "enum.CMHolsterLayers.Fill" ]
+      visible: false
+    - state: icon
+    - state: half
+      map: [ "openLayer" ]
+    - state: full
+      map: [ "closedLayer" ]
+  - type: Clothing
+    slots:
+    - suitStorage
+    - belt
+    sprite: _RMC14/Objects/Clothing/Belt/mateba_belt.rsi
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,13,1 # 7 slots
+    blacklist:
+      tags:
+      - CMFirstAidKit # TODO RMC14
+  #      - EngineerKit # TODO RMC14
+  - type: Tag
+    tags:
+    - RMCMatebaHolster
+  - type: FixedItemSizeStorage
+  - type: CMHolster
+    whitelist:
+      components:
+      - Gun
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-one-gun
+      whitelist:
+        components:
+        - Gun
+
+- type: Tag
+  id: RMCMatebaHolster
+
+- type: entity
+  parent: RMCMatebaBelt
+  id: RMCMatebaBeltFilled
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCSpeedLoaderMateba
+      amount: 5
+    - id: RMCWeaponRevolverMateba
+
+- type: entity
+  parent: RMCBeltHolsterPistol
+  id: RMCMK80BeltFilled
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMMagazinePistolMK80
+      amount: 6
+    - id: CMWeaponPistolMK80
+
+- type: entity
+  parent: RMCBeltHolsterPistol
+  id: RMCM1984BeltFilled
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMMagazinePistolM1984
+      amount: 6
+    - id: CMWeaponPistolM1984
+
+- type: entity
+  parent: RMCBeltHolsterPistol
+  id: CMM77BeltFilled
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMMagazinePistolM77AP
+      amount: 6
+    - id: CMWeaponPistolM77
+
+- type: entity
+  parent: RMCBeltHolsterRevolver
+  id: RMCM44BeltFilled
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: RMCSpeedLoaderM44
+      amount: 6
+    - id: RMCWeaponRevolverM44
+
+- type: entity
+  parent: CMBeltBaseStorage
+  id: RMCBeltXM51
+  name: M276 pattern XM51 holster rig
+  description: The M276 is the standard load-bearing equipment of the UNMC. It consists of a modular belt with various clips. This version is for the XM51 breaching scattergun, allowing easier storage of the weapon. It features pouches for storing two magazines along with extra shells.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/xm51.rsi
+    layers:
+    - state: xm51
+      map: [ "enum.CMHolsterLayers.Fill" ]
+      offset: 0.35, 0
+      visible: false
+    - state: icon
+  - type: Clothing
+    slots:
+    - belt
+    - suitStorage
+    sprite: _RMC14/Objects/Clothing/Belt/xm51.rsi
+  - type: Storage
+    maxItemSize: Large
+    grid:
+    - 0,0,15,1 # 8 slots
+    whitelist:
+      tags:
+      - RMCWeaponShotgunXM51
+      - RMCMagazineShotgunXM51
+      - RMCShellShotgun # TODO RMC14 bullet handfuls
+  - type: FixedItemSizeStorage
+  - type: CMHolster
+    whitelist:
+      components:
+      - Gun
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-one-gun
+      whitelist:
+        components:
+        - Gun
+    - popup: rmc-storage-limit-max-mags
+      count: 2
+      whitelist:
+        tags:
+        - RMCMagazineShotgunXM51
+  - type: CMStorageVisualizer
+    storageClosed: null
+    storageOpen: null
+  - type: Tag
+    tags:
+    - RMCXM51Holster
+
+- type: Tag
+  id: RMCXM51Holster
+
+- type: entity
+  parent: CMBeltBaseStorage
+  id: RMCM300SOCOMBelt
+  name: M300 pattern .458 SOCOM loading rig
+  description: An ammunition belt designed to hold the large .458 SOCOM caliber bullets for the XM88 heavy rifle.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/SOCOM.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Clothing/Belt/SOCOM.rsi
+  - type: Item
+    size: Large
+  - type: Storage
+    maxItemSize: Large
+    grid:
+    - 0,0,13,3 # 14 slots
+    whitelist:
+      tags:
+      - RMCCartridge458SOCOM
+  - type: IgnoreContentsSize
+    items:
+      tags:
+      - CMMagazineRifle
+      - CMMagazineSmg
+      - RMCShellShotgun
+  - type: FixedItemSizeStorage
+  - type: Tag
+    tags:
+    - RMCBeltSOCOM
+
+- type: Tag
+  id: RMCBeltSOCOM
+
+- type: entity
+  parent: CMBeltBaseStorage
+  id: RMCDeagleBelt
+  name: M276 pattern Desert Eagle holster rig
+  description: The M276 is the standard load-bearing equipment of the UNMC. It consists of a modular belt with various clips. This version is for the powerful Desert Eagle, along with six small pouches for magizines.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/Belt/holster_pistol.rsi
+    layers:
+    - state: cdeagle
+      map: [ "enum.CMHolsterLayers.Fill" ]
+      visible: false
+    - state: icon
+    - state: half
+      map: [ "openLayer" ]
+    - state: full
+      map: [ "closedLayer" ]
+  - type: Clothing
+    slots:
+    - suitStorage
+    - belt
+    sprite: _RMC14/Objects/Clothing/Belt/holster_pistol.rsi
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,13,1 # 7 slots
+    blacklist:
+      tags:
+      - CMFirstAidKit # TODO RMC14
+  #      - EngineerKit # TODO RMC14
+  - type: Tag
+    tags:
+    - RMCDeagleHolster
+  - type: FixedItemSizeStorage
+  - type: CMHolster
+    whitelist:
+      components:
+      - Gun
+  - type: LimitedStorage
+    limits:
+    - popup: rmc-storage-limit-one-gun
+      whitelist:
+        components:
+        - Gun
+
+- type: Tag
+  id: RMCDeagleHolster
+
+- type: entity
+  parent: RMCDeagleBelt
+  id: RMCDeagleBeltFilled
+  suffix: Filled
+  components:
+  - type: StorageFill
+    contents:
+    - id: CMMagazinePistolDeagleHI
+      amount: 4
+    - id: CMMagazinePistolDeagleHIAP
+      amount: 2
+    - id: CMWeaponPistolCOdeagle

--- a/co_deserteagle.yml
+++ b/co_deserteagle.yml
@@ -1,0 +1,179 @@
+- type: entity
+  parent: CMWeaponPistolBase
+  id: CMWeaponPistolCOdeagle
+  name: Vintage Desert Eagle
+  description: A bulky 50 caliber pistol with a serious kick, probably taken from some museum somewhere. The carbon fiber grip signifies this much -- it's hella classy.
+  components:
+  - type: Gun
+    selectedMode: SemiAuto
+    availableModes:
+    - SemiAuto
+    soundGunshot:
+      path: /Audio/_RMC14/Weapons/Guns/Gunshots/gun_DE50.ogg
+  - type: RMCSelectiveFire
+    scatterWielded: 5
+    scatterUnwielded: 8
+    baseFireRate: 1.43
+    burstScatterMult: 7
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Pistols/deagle.rsi
+  - type: Clothing
+    sprite: _RMC14/Objects/Weapons/Guns/Pistols/deagle.rsi
+  - type: RMCWeaponAccuracy
+    accuracyMultiplier: 7.2
+    accuracyMultiplierUnwielded: 3.9
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        insertSound: /Audio/_RMC14/Weapons/Guns/Reload/gun_88m4_reload.ogg
+        ejectSound: /Audio/_RMC14/Weapons/Guns/Reload/gun_88m4_unload.ogg
+        priority: 2
+        whitelist:
+          tags:
+          - CMMagazinePistolDeagleHI
+          - CMMagazinePistolDeagleHIAP
+        startingItem: CMMagazinePistolDeagleHI
+  - type: AttachableHolder
+    slots:
+      rmc-aslot-barrel:
+        whitelist:
+          tags:
+          - RMCAttachmentBarrelCharger
+          - RMCAttachmentExtendedBarrel
+          - RMCAttachmentRecoilCompensator
+      rmc-aslot-rail:
+        whitelist:
+          tags:
+          - RMCAttachmentRailFlashlight
+          - RMCAttachmentS5RedDotSight
+          - RMCAttachmentS6ReflexSight
+      rmc-aslot-underbarrel:
+        whitelist:
+          tags:
+          - RMCAttachmentLaserSight
+  - type: AttachableHolderVisuals
+    offsets:
+      rmc-aslot-barrel: 0.75, 0.070
+      rmc-aslot-rail: 0.090, 0.125
+      rmc-aslot-underbarrel: 0.312, -0.25
+
+- type: entity
+  parent: CMBaseMagazinePistol
+  id: CMMagazinePistolDeagleHI
+  name: High Impact Desert Eagle Magazine (.50AE)
+  components:
+  - type: Tag
+    tags:
+    - CMMagazinePistol
+    - CMMagazinePistolDeagleHI
+  - type: BallisticAmmoProvider
+    mayTransfer: True
+    whitelist:
+      tags:
+      - CMCartridgePistolHI50AE
+    proto: CMCartridgePistolHI50AE
+    capacity: 7
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Ammunition/Magazines/m1984.rsi
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  id: CMCartridgePistolHI50AE
+  name: cartridge (High Impact .50AE)
+  parent: CMCartridgePistolBase
+  components:
+  - type: Tag
+    tags:
+    - Cartridge
+    - CMCartridgePistolHI50AE
+  - type: CartridgeAmmo
+    proto: CMBulletPistolHI50AE
+
+- type: entity
+  parent: CMBulletBase
+  id: CMBulletPistolHI50AE
+  name: bullet (HI50AE)
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 84
+  - type: CMArmorPiercing
+    amount: 5
+  - type: RMCStunOnHit
+    maxRange: 4
+    stunTime: 1
+  - type: RMCProjectileAccuracy
+    accuracy: 90
+
+- type: entity
+  parent: CMBaseMagazinePistol
+  id: CMMagazinePistolDeagleHIAP
+  name: High Impact Armor-Piercing Desert Eagle Magazine (.50AE)
+  components:
+  - type: Tag
+    tags:
+    - CMMagazinePistol
+    - CMMagazinePistolDeagleHIAP
+  - type: BallisticAmmoProvider
+    mayTransfer: True
+    whitelist:
+      tags:
+      - CMCartridgePistolHIAP50AE
+    proto: CMCartridgePistolHIAP50AE
+    capacity: 7
+  - type: Sprite
+    sprite: _RMC14/Objects/Weapons/Guns/Ammunition/Magazines/m1984.rsi
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  id: CMCartridgePistolHIAP50AE
+  name: cartridge (High Impact Armor-Piercing .50AE)
+  parent: CMCartridgePistolBase
+  components:
+  - type: Tag
+    tags:
+    - Cartridge
+    - CMCartridgePistolHIAP50AE
+  - type: CartridgeAmmo
+    proto: CMBulletPistolHIAP50AE
+
+- type: entity
+  parent: CMBulletBase
+  id: CMBulletPistolHIAP50AE
+  name: bullet (HIAP50AE)
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 63
+  - type: CMArmorPiercing
+    amount: 50
+  - type: RMCStunOnHit
+    maxRange: 4
+    stunTime: 1
+  - type: RMCProjectileAccuracy
+    accuracy: 90
+
+- type: Tag
+  id: CMMagazinePistolDeagleHI
+
+- type: Tag
+  id: CMCartridgePistolHI50AE
+
+- type: Tag
+  id: CMMagazinePistolDeagleHIAP
+
+- type: Tag
+  id: CMCartridgePistolHIAP50AE
+
+

--- a/command.yml
+++ b/command.yml
@@ -1,0 +1,1085 @@
+# Staff Officer #
+
+# Equipment Vend
+- type: entity
+  parent: ColMarTechBase
+  id: ColMarTechStaffOfficerEquipment
+  name: ColMarTech Staff Officer Equipment Rack
+  description: An automated equipment vendor for Staff Officers
+  components:
+  - type: AccessReader
+    access:
+    - [ "CMAccessCommand" ]
+  - type: Sprite
+    sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/equipment.rsi
+  - type: CMAutomatedVendor
+    jobs:
+    - CMStaffOfficer
+    sections:
+    - name: Standard Equipment
+      takeAll: CMStandard
+      entries:
+      - id: CMBootsBlackFilled
+      - id: RMCHeadsetMarineCommand
+      - id: CMMRE
+    - name: Standard Equipment
+      takeAll: CMUniform
+      entries:
+      - id: CMJumpsuitBO
+        name: service uniform
+      - id: CMJumpsuitOperations
+        name: operations uniform
+        recommended: true
+      - id: CMHandsBlackMarine
+    - name: Jacket
+      choices: { CMCoat: 1}
+      entries:
+      - id: CMCoatOfficer
+        recommended: true
+    - name: Hat
+      choices: { CMHat: 1 }
+      entries:
+      - id: CMHeadBeret
+        recommended: true
+      - id: CMHeadBeretTan
+        recommended: true
+      - id: CMHeadCap
+        recommended: true
+      - id: CMHeadCapOfficer
+        recommended: true
+      - id: CMHeadCapPeakedService
+        recommended: true
+    - name: Personal Sidearm
+      choices: { CMWeapon: 1 }
+      entries:
+      - id: RMCWeaponRevolverM44
+        recommended: true
+      - id: CMWeaponPistolM1984
+        recommended: true
+      - id: CMWeaponPistolMK80
+        recommended: true
+    - name: Backpack
+      choices: { CMBackpack: 1 }
+      entries:
+      - id: CMBackpack
+      - id: CMSatchel
+    - name: Other Supplies
+      entries:
+      - id: RMCBinoculars
+        points: 5
+      - id: RMCRangefinder
+        points: 8
+      - id: RMCLaserDesignator
+        points: 12
+        recommended: true
+      - id: RMCFlashlight
+        points: 1
+        recommended: true
+      - id: RMCMotionDetector
+        points: 5
+        recommended: true
+      - id: SprayBottleSpaceCleaner
+        points: 2
+      - id: RMCWhistle
+        points: 5
+
+# Armoury Vend
+
+- type: entity
+  parent: ColMarTechBase
+  id: ColMarTechStaffOfficerWeapon
+  name: ColMarTech Staff Officer Armory Weapon Rack
+  description: An automated combat equipment vendor for Staff Officers.
+  components:
+  - type: AccessReader
+    access:
+    - [ "CMAccessCommand" ]
+  - type: Sprite
+    sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/guns.rsi
+  - type: CMAutomatedVendor
+    jobs:
+    - CMStaffOfficer
+    sections:
+    - name: Combat Equipment
+      takeAll: CMCombatEquipment
+      entries:
+      - id: RMCArmorM3SO
+      - id: RMCArmorHelmetM10SO
+      - id: CMBootsBlackFilled
+      - id: CMHandsBlackMarine
+      - id: CMMRE
+      - id: RMCGlassesAviators
+      - id: RMCM5Bayonet
+    - name: Specialisation Kit
+      choices: { CMBundle: 1 }
+      entries:
+      - id: CMVendorBundleCombatTechnicianEssentials
+        recommended: true
+      - id: CMVendorBundleSquadMedicalEssentials
+        recommended: true
+    - name: Belt
+      choices: { CMBelt: 1 }
+      entries:
+      - id: RMCBeltUtilityGeneral
+        recommended: true
+      - id: CMBeltMarine
+        recommended: true
+      - id: CMBeltUtilityFilled
+      - id: CMBeltMedicBagFilled
+      - id: CMBeltMedicalFilled
+      - id: RMCBeltHolsterSMGPouch
+      #- id: CMBeltM82F # TODO RMC14 M82F Flare Gun Belt
+      - id: RMCM276ShotgunShellLoadingRig
+      - id: RMCBeltGrenade
+    - name: Pouches
+      choices: { CMPouches: 2 }
+      entries:
+      - id: RMCPouchAutoinjector
+      - id: RMCPouchConstruction
+      #- id: RMCPouchDocuments # TODO RMC14 Documents Pouch
+      - id: RMCPouchElectronicsFill
+      - id: RMCPouchFirstAidInjectors
+        name: first-aid pouch (refillable injectors)
+      - id: RMCPouchFirstAidSplintsGauzeOintment
+        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+      - id: RMCPouchFirstAidPills
+        name: first-aid pouch (pills)
+      - id: RMCPouchFirstResponder
+      - id: RMCPouchFlareFilled
+      #- id: RMCPouchFuelTank # TODO RMC14 Fuel Tank Pouch
+      - id: RMCPouchGeneralLarge
+        recommended: true
+      - id: RMCPouchMagazineLarge
+      - id: RMCPouchShotgunLarge
+      - id: RMCPouchMagazinePistolLarge
+      - id: RMCPouchMedical
+      - id: RMCPouchMedkit
+      - id: RMCPouchPistol
+      #- id: RMCPouchSling # TODO RMC14 Sling Pouch
+                           # This has a comment saying "implement this", going to leave it commented out.
+      - id: RMCPouchToolsFill
+    - name: Accessories
+      choices: { CMAccessories: 1 }
+      entries:
+      - id: CMWebbingBrown
+        recommended: true
+      - id: CMWebbingBlack
+        recommended: true
+      - id: CMWebbingPouch
+      - id: CMWebbing
+      - id: CMWebbingHolster
+    - name: Mask
+      choices: { CMMask: 1 }
+      entries:
+      - id: CMMaskGas
+      - id: CMMaskCoif
+      - id: RMCMaskRebreather
+    - name: Other Supplies
+      entries:
+      # - id: CMHelmetVisorMedical
+      #   points: 5
+      - id: RMCAttachmentMagneticHarness
+        points: 12
+      - id: RMCBackpackRTO
+        points: 15
+      - id: RMCBinoculars
+        points: 5
+      - id: RMCRangefinder
+        points: 8
+      - id: RMCLaserDesignator
+        points: 12
+        recommended: true
+      #- id: RMCDataDetector # TODO RMC14 Data Detector
+      #  points: 5
+      #- id: RMCFultonRecoveryDevice # TODO RMC14 Fulton Recovery
+      - id: RMCFlashlight
+        points: 1
+      - id: RMCMotionDetector
+        points: 5
+        recommended: true
+      - id: SprayBottleSpaceCleaner
+        points: 2
+      - id: RMCWhistle
+        points: 5
+      #- id: RMCScabbardMacheteFilled # TODO RMC14 Machete Scabbard
+      #  points: 5
+
+
+# Executive Officer #
+
+# Weapon Vendor
+- type: entity
+  parent: ColMarTechBase
+  id: ColMarTechExecutiveOfficerWeapon
+  name: ColMarTech Executive Officer Weapon Rack
+  description: An automated weapons rack for the Executive Officer. It features a decent selection of weaponry meant only for the second in command of a ship.
+  components:
+  - type: AccessReader
+    access:
+    - [ "CMAccessCommand" ]
+  - type: Sprite
+    sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/guns.rsi
+  - type: CMAutomatedVendor
+    jobs:
+    - CMExecutiveOfficer
+    sections:
+    - name: Captain's Primary
+      choices: { CMPrimary: 1 }
+      entries:
+      - id: WeaponRifleM54C # TODO RMC14 MK1 Pulse Rifle needs to replace this; as well as the magazines below.
+      - id: WeaponShotgunM42A2
+    - name: Primary Ammunition
+      entries:
+      - id: CMMagazineRifleM54C
+        points: 40
+        recommended: true
+      - id: CMMagazineRifleM54CAP
+        points: 60
+        recommended: true
+      - id: RMCBoxShotgunBuckshot
+        points: 20
+      - id: RMCBoxShotgunSlugs
+        points: 20
+      - id: RMCBoxShotgunFlechette
+        points: 20
+    - name: Specilisation Kit
+      choices: { CMBundle: 1 }
+      entries:
+      - id: CMVendorBundleSquadMedicalEssentials
+      - id: CMVendorBundleCombatTechnicianEssentials
+    - name: Explosives
+      entries:
+      - id: CMPacketGrenadeHighExplosiveFilled
+        points: 15
+      - id: CMPacketGrenadeFragFilled
+        points: 15
+      #- id: CMPacketGrenadeWPFilled # TODO RMC14 White Phosphorus (WP) Grenades
+      #  points: 15
+    - name: Rail Attachments
+      entries:
+      - id: RMCAttachmentMagneticHarness
+        points: 12
+      - id: RMCAttachmentS5RedDotSight
+        points: 15
+      - id: RMCAttachmentS6ReflexSight
+        points: 15
+      - id: RMCAttachmentS42xTelescopicMiniscope
+        points: 15
+    # - name: Helmet Visors # TODO RMC14 Port Helmet Welding Visor
+    #   entries:
+    #   - id: RMCHelmetWeldingVisor
+    #     points: 5
+    #     recommended: true
+    - name: Underbarrel Attachments
+      entries:
+      - id: RMCAttachmentLaserSight
+        points: 15
+      - id: RMCAttachmentAngledGrip
+        points: 15
+      - id: RMCAttachmentVerticalGrip
+        points: 15
+      - id: RMCAttachmentU7UnderbarrelShotgun
+        points: 15
+      - id: RMCAttachmentUnderbarrelExtinguisher
+        points: 15
+      - id: RMCAttachmentU1GrenadeLauncher
+        points: 5
+    - name: Barrel Attachments
+      entries:
+      - id: RMCAttachmentExtendedBarrel
+        points: 15
+      - id: RMCAttachmentRecoilCompensator
+        points: 15
+      - id: RMCAttachmentSuppressor
+        points: 15
+    - name: Other Supplies
+      entries:
+      - id: CMHandsInsulated
+        points: 3
+      - id: RMCPouchMacheteFilled
+        points: 5
+      - id: CMEntrenchingTool
+        points: 1
+      - id: RMCBinoculars
+        points: 5
+      - id: RMCRangefinder
+        points: 8
+      - id: RMCLaserDesignator
+        points: 12
+      - id: RMCWhistle
+        points: 5
+      - id: RMCFlashlight
+        points: 1
+
+# Commanding Officer #
+
+# Clothing Vend
+
+- type: entity
+  parent: ColMarTechBase
+  id: ColMarTechCommandingOfficerClothing
+  name: ColMarTech Commanding Officer Clothing Rack
+  description: An automated closet hooked up to a colossal storage of standard-issue dress uniform variants.
+  components:
+  - type: AccessReader
+    access:
+    - [ "CMAccessCO" ]
+  - type: Sprite
+    sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/clothing.rsi
+  - type: CMAutomatedVendor
+    jobs:
+    - CMCommandingOfficer
+    sections:
+    - name: Utility
+      entries:
+      - id: CMJumpsuitBO
+      - id: CMJumpsuitOperations
+      - id: CMHeadCapCO
+      - id: CMHeadBeretCO
+      - id: CMBootsBlackFilled
+      - id: CMHandsBlackMarine
+    - name: Utility Extras
+      entries:
+      - id: RMCSunglasses
+      - id: RMCSunglassesBig
+      - id: RMCGlassesAviators
+      - id: RMCGlassesMarineRpg
+    - name: Service
+      entries:
+      - id: CMJumpsuitCOService
+      - id: CMJumpsuitCOFormalWhite
+      - id: CMJumpsuitCOFormalBlack
+      - id: CMCoatOfficer # TODO: Check this is the service variant
+      - id: CMCoatMP
+      - id: RMCShoesLaceup
+      - id: RMCShoesLaceupBrown # RMC Addition
+    - name: Service Headwear
+      entries:
+      - id: CMHeadBeretCO
+      - id: CMHeadBeretCOWhite
+      - id: CMHeadBeretCOBlack
+      - id: CMHeadCap # TODO: Check this is the service variant. If so, parent and rename.
+    - name: Service Extras
+      entries:
+      - id: CMCoatCOBomber
+    # - name: Dress  # TODO: Check if this is locked to Council Members; this seems weird for a CO to be able to wear
+    #   entries:
+    # - name: Dress Headwear
+    # - name: Dress Extras
+
+# Equipment Vend
+- type: entity
+  parent: ColMarTechBase
+  id: ColMarTechCommandingOfficerEquipment
+  name: ColMarTech Commanding Officer Equipment Rack
+  description: An automated equipment vendor for the Commanding Officer. Contains a prime selection of equipment for only the UNMC's top officers.
+  components:
+  - type: AccessReader
+    access:
+    - [ "CMAccessCO" ]
+  - type: Sprite
+    sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/equipment.rsi
+  - type: CMAutomatedVendor
+    jobs:
+    - CMCommandingOfficer
+    sections:
+    - name: Standard Equipment
+      takeAll: CMStandard
+      entries:
+      - id: CMHeadsetSeniorCommand
+      - id: CMMRE
+  # - name: Commanding Officer Essentials Kit #TODO: Make this.
+  #   takeAll: CMBundle
+  #   entries:
+  #   - id: CMCommandingOfficerEssentialsBundle # TODO RMC14 Megaphone , Paper Map , Laser Designator
+    - name: Bags
+      choices: { CMBag: 1 }
+      entries:
+      - id: CMBackpackCommand
+        recommended: true
+      #- id: CMSatchelCommandSecure # TODO RMC14 Secure Satchel (ID LOCK)
+    - name: Combat Equipment
+      takeAll: CMCombatEquipment
+      entries:
+      - id: RMCArmorM3CO
+      - id: CMArmorHelmetM10CO
+      - id: RMCHandsCOGloves
+      - id: CMBootsBlackFilled
+    - name: Accessories
+      choices: { CMAccessories: 1 }
+      entries:
+      - id: CMWebbingBrown
+        recommended: true
+      - id: CMWebbingBlack
+    #- id: CMTacticalWaistcoat # TODO Port Waistcoat
+      - id: CMWebbingPouch
+      - id: CMWebbing
+      - id: CMWebbingHolster
+    - name: Huds
+      choices: { CMHud: 1 }
+      entries:
+      - id: RMCGlassesMedicalHUDGlasses
+        recommended: true
+      - id: CMGlassesSecurity
+    - name: Belt
+      choices: { CMBelt: 1 }
+      entries:
+      - id: RMCBeltUtilityGeneral
+        recommended: true
+      - id: CMBeltSecurityMPFilled
+        recommended: true
+      - id: CMBeltMedicBagFilled
+        recommended: true
+      - id: CMBeltMarine
+        recommended: true
+      - id: CMBeltUtilityCombat
+        recommended: true
+      #- id: CMBeltM82F # TODO RMC14 M82F Flare Gun Belt
+      - id: RMCM276ShotgunShellLoadingRig
+    - name: Pouches
+      choices: { CMPouch: 2 }
+      entries:
+      - id: RMCPouchFirstAidInjectors
+        name: first-aid pouch (refillable injectors)
+      - id: RMCPouchFirstAidSplintsGauzeOintment
+        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+      - id: RMCPouchFirstAidPills
+        name: first-aid pouch (pills)
+        recommended: true
+      - id: RMCPouchMedkit
+      - id: RMCPouchAutoinjectorFill
+      - id: RMCPouchGeneralLarge
+      - id: RMCPouchMagazinePistolLarge
+      - id: RMCPouchMagazineLarge
+      - id: RMCPouchPistol
+      - id: RMCPouchShotgunLarge
+      - id: RMCPouchToolsFill
+
+# Weapon Vend
+- type: entity
+  parent: ColMarTechBase
+  id: ColMarTechCommandingOfficerWeapon
+  name: ColMarTech Commanding Officer Weapon Rack
+  description: An automated weapons rack for the Commanding Officer. It features a robust selection of weaponry meant only for the UNMC's top officers.
+  components:
+  - type: AccessReader
+    access:
+    - [ "CMAccessCO" ]
+  - type: Sprite
+    sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/guns.rsi
+  - type: CMAutomatedVendor
+    jobs:
+    - CMCommandingOfficer
+    sections:
+    - name: Commander's Primary
+      choices: { CMProtagGun: 1 }
+      entries:
+      - id: WeaponRifleM54C # TODO RMC14 Port M46C Protag Gun
+        name: Commander's M54C
+        recommended: true # TODO RMC14 Make choices: colour the options brown
+      - id: CMSmartGunOperatorEquipmentCaseBelt # TODO RMC14 Port M56C Smart Protag Gun
+        name: Commander's Smartgun
+        recommended: true # TODO RMC14 Make choices: colour the options brown
+    - name: Commander's Secondary
+      choices: { CMSecondary: 1 }
+      entries:
+      - id: RMCDeagleBeltFilled
+      - id: RMCMatebaBeltFilled
+    - name: Primary Ammunition
+      entries:
+      - id: CMMagazineRifleM54C # TODO RMC14 Port MK1 Pulse Rifle
+        points: 30
+        recommended: true
+      - id: CMMagazineRifleM54CAP # TODO RMC14 Port Mk1 Pulse Rifle
+        points: 40
+        recommended: true
+      - id: CMMagazineRifleM54CExt
+        points: 20
+      # - id: CMMagazineRifleM54CAP # When MK1 is ported; replace first two mags with MK1 variants and uncomment this.
+      #   points: 20
+      - id: RMCMagazineSmartGun
+        points: 20
+    - name: Sidearm Ammunition
+      entries:
+      - id: RMCSpeedLoaderMateba
+        points: 15
+    #   - id: CMMagazineMatebaAP  # TODO RMC14 Port More Sidearm Ammo
+    #     points: 20
+      - id: CMMagazinePistolDeagleHI
+        points: 15
+      - id: CMMagazinePistolDeagleHIAP
+        points: 20
+    - name: Shotgun Ammunition
+      entries:
+      - id: RMCBoxShotgunBuckshot
+        points: 20
+      - id: RMCBoxShotgunSlugs
+        points: 20
+      - id: RMCBoxShotgunFlechette
+        points: 20
+    - name: Special Ammunition
+      entries:
+      #- id: M54C Incendiary Magazine
+      #- id: M54C Rubber Magazine
+      - id: RMCBoxShotgunBeanbag
+        points: 10
+    - name: Explosives
+      entries:
+      - id: CMPacketGrenadeHighExplosiveFilled
+        points: 15
+      - id: CMPacketGrenadeFragFilled
+        points: 15
+      #- id: CMPacketGrenadesWPFilled # TODO RMC14 Port White Phosphorus (WP) Grenades
+    - name: Rail Attachments
+      entries:
+      - id: RMCAttachmentS5RedDotSight
+        points: 15
+      - id: RMCAttachmentS6ReflexSight
+        points: 15
+      - id: RMCAttachmentS42xTelescopicMiniscope
+        points: 15
+    # - name: Helmet Visors # TODO RMC14 Port Helmet Visors
+    #   entries:
+    #   - id: CMHelmetVisor
+    - name: Underbarrel Attachments
+      entries:
+      - id: RMCAttachmentLaserSight
+        points: 15
+      - id: RMCAttachmentAngledGrip
+        points: 15
+      - id: RMCAttachmentVerticalGrip
+        points: 15
+      - id: RMCAttachmentU7UnderbarrelShotgun
+        points: 15
+      - id: RMCAttachmentUnderbarrelExtinguisher # TODO: Check this works, prototype looks sussy
+        points: 15
+      #- id: RMCAttachmentUnderbarrelFlamethrower # TODO RMC14 Underbarrel FLamethrower
+      #  points: 15
+      - id: RMCAttachmentU1GrenadeLauncher
+        points: 5
+    - name: Barrel Attachments
+      entries:
+      - id: RMCAttachmentExtendedBarrel
+        points: 15
+      - id: RMCAttachmentRecoilCompensator
+        points: 15
+      - id: RMCAttachmentSuppressor
+        points: 15
+
+# Senior Officer Vendors
+
+# Drip Vendor
+#
+- type: entity
+  parent: ColMarTechBase
+  id: ColMarTechSeniorOfficerEquipment
+  name: ColMarTech Senior Officer Equipment Rack
+  description: An automated equipment vendor for Senior Officers.
+  components:
+  - type: AccessReader
+    access:
+    - [ "CMAccessCommand" ]
+  - type: Sprite
+    sprite: _RMC14/Structures/Machines/VendingMachines/ColMarTech/equipment.rsi
+  - type: CMAutomatedVendor
+    jobs:
+    - CMExecutiveOfficer
+    sections:
+    - name: Standard Equipment
+      takeAll: CMStandard
+      entries:
+      - id: CMHeadsetSeniorCommand
+      - id: CMSatchel
+      - id: CMMRE
+    - name: Uniform # TODO: Port this.
+      choices: { CMUniform: 1 }
+      entries:
+      - id: CMJumpsuitBO
+      - id: CMJumpsuitOperations
+      - id: RMCVendorBundleXOFormal
+    - name: Personal Weapon
+      choices: { CMWeapon: 1 }
+      entries:
+      - id: RMCMK80BeltFilled
+        name: MK80 Pistol
+        recommended: true
+      - id: RMCM1984BeltFilled
+        name: M1984 Pistol
+      - id: CMM77BeltFilled
+        name: M77 Pistol
+      - id: RMCM44BeltFilled
+        name: M44 Revolver
+    - name: Belt
+      choices: { CMBelt: 1 }
+      entries:
+      - id: RMCBeltUtilityGeneral
+        recommended: true
+      - id: CMBeltSecurityMPFilled
+        recommended: true
+      - id: CMBeltMedicBag
+        recommended: true
+      - id: CMBeltMarine
+        recommended: true
+      - id: CMBeltUtilityCombat
+        recommended: true
+    - name: Combat Equipment
+      takeAll: CMEquipment
+      entries:
+      - id: RMCArmorM3SO
+      - id: RMCArmorHelmetM10SO
+      - id: CMBootsBlackFilled
+      - id: CMHandsBlackMarine
+      #- id: CMBeltM82F # TODO RMC14 M82F Flare Gun Belt
+    - name: Eyewear
+      choices: { CMEyewear: 1 }
+      entries:
+      - id: RMCGlassesMedicalHUDGlasses
+        recommended: true
+      - id: CMGlassesSecurity
+      - id: RMCSunglasses
+        recommended: true
+      - id: RMCGlassesAviators
+    # - name: Patches # TODO RMC14 Make Patches
+    #   entries:
+    #   - id: CMUNMCPatch
+    #   - id: CMFallingFalconsPatch
+    - name: Pouches
+      choices: { CMPouches: 2 }
+      entries:
+      - id: RMCPouchFirstAidInjectors
+        name: first-aid pouch (refillable injectors)
+      - id: RMCPouchFirstAidSplintsGauzeOintment
+        name: first-aid pouch (gauze, ointment) # TODO RMC14 splints comma
+      - id: RMCPouchFirstAidPills
+        name: first-aid pouch (pills)
+        recommended: true
+      - id: RMCPouchGeneralLarge
+      - id: RMCPouchMagazineLarge
+      - id: RMCPouchShotgunLarge
+      - id: RMCPouchMagazinePistolLarge
+      - id: RMCPouchMedical
+      - id: RMCPouchMedkit
+      - id: RMCPouchPistol
+      #- id: RMCPouchSling # TODO RMC14 Sling Pouch
+                           # This has a comment saying "implement this", going to leave it commented out.
+      - id: RMCPouchToolsFill
+      - id: RMCPouchConstruction
+      - id: RMCPouchElectronicsFill
+      - id: RMCPouchFlareFilled
+      #- id: RMCPouchFuelTank # TODO RMC14 Fuel Tank Pouch
+    - name: Accessories
+      choices: { CMAccessories: 1 }
+      entries:
+      - id: CMWebbingBrown
+        recommended: true
+      - id: CMWebbingBlack
+        recommended: true
+      - id: CMWebbingPouch
+      - id: CMWebbing
+      - id: CMWebbingHolster
+    - name: Hats
+      choices: { CMHat: 1 }
+      entries:
+      - id: CMHeadBeret # TODO: Port Officer Beret
+      - id: CMHeadCapPeakedService
+      - id: CMHeadCap # TODO: Port Patrol Cap
+      - id: CMHeadCapOfficer
+
+- type: entity
+  parent: CMVendorBundleRiflemanApparel
+  id: RMCVendorBundleXOFormal
+  name: formal uniform
+  description: Contains a peaked cap, formal uniform and jacket.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Clothing/OuterClothing/Coats/coat_formal.rsi
+    state: icon
+  - type: CMVendorBundle
+    bundle:
+    - CMHeadCapPeakedFormal
+    - CMCoatXOFormal
+    - CMJumpsuitXOFormal
+
+#   - type: CMAutomatedVendor
+#     jobs:
+#     - CMChiefMP
+#     sections:
+#     - name: POLICE SET (MANDATORY)
+#       takeAll: CMStandard
+#       entries:
+#       - id: RMCVendorBundleMilitaryPoliceApparelCMP
+#     - name: STANDARD EQUIPMENT
+#       takeAll: CMStandard
+#       entries:
+#       - id: CMJumpsuitWO
+#       - id: CMHeadsetSeniorCommand #ToDo: convert Headset to CMP comms
+#       - id: CMHandsBlackMarine
+#       - id: CMBootsBlackFilled
+#     - name: ARMOR
+#       takeAll: CMStandard
+#       entries:
+#       - id: CMArmorM3WO
+#       - id: CMArmorHelmetM10ChiefMP
+#       - id: CMHandsBlackMarine
+#       - id: CMHeadBeretWO
+#     - name: HANDGUN CASE
+#       choices: { CMWeapon: 1 }
+#       entries:
+#       - id: CMWeaponPistolMK80  # These all come inside belts; but these don't exist so... # TODO RMC14 Pistol Belt Fills
+#       - id: RMCWeaponRevolverM44 # TODO ADD CASE.
+#       - id: CMWeaponPistolM1984 # TODO ADD CASE.
+#     - name: BACKPACK
+#       choices: { CMBackpack: 1 }
+#       entries:
+#       - id: CMSatchelSecurity
+#     - name: BELT
+#       choices: { CMBelt: 1 }
+#       entries:
+#       - id: RMCBeltUtilityGeneral
+#       #- id: RMCBeltGunPistol # TODO Add belt.
+#       #- id: RMCBeltGunRevolver # TODO Add belt.
+#     - name: Combat Equipment
+#       takeAll: CMEquipment
+#       entries:
+#       - id: CMArmorM4 # TODO: Port Officer Armour
+#       - id: ArmorHelmetM10 # TODO: Port Officer Helmet
+#       - id: CMBootsBlackFilled
+#       - id: CMHandsBlackMarine
+#       #- id: CMBeltM82F # TODO RMC14 M82F Flare Gun Belt
+#     - name: POUCHES
+#       choices: { CMPouches: 2 }
+#       entries:
+#       - id: RMCPouchGeneralLarge
+#       - id: RMCPouchFirstAidInjectors
+#       - id: RMCPouchFirstAidSplintsGauzeOintment
+#       - id: RMCPouchFirstAidPills
+#       - id: RMCPouchMagazinePistol
+#       - id: RMCPouchPistol
+#     - name: MASK
+#       choices: { CMMask: 1 }
+#       entries:
+#       - id: CMMaskGas
+#       - id: CMMaskCoif
+#       #- id: RMCMaskRebreather
+#     - name: ACCESSORIES
+#       choices: { CMAccessories: 1 }
+#       entries:
+#       - id: CMWebbingBrown
+#       - id: CMWebbingBlack
+#       - id: CMWebbingPouch
+#       - id: CMWebbing
+
+# - type: entity
+#   parent: CMVendorBundleRiflemanApparel
+#   id: RMCVendorBundleMilitaryPoliceApparelCMP
+#   name: Essential Police Set
+#   description: Contains security HUD-glasses, a filled security belt and a M10 helmet.
+#   components:
+#   - type: Sprite
+#     sprite: _RMC14/Objects/Clothing/Eyes/Glasses/security_glasses.rsi
+#     state: icon
+#   - type: CMVendorBundle
+#     bundle:
+#     - CMGlassesSecurity
+#     - CMBeltSecurityMPFilled
+
+
+#   - type: CMAutomatedVendor
+#     jobs:
+#     - CMChiefEngineer
+#     sections:
+#     - name: SHIPSIDE GEAR
+#     - name: STANDARD EQUIPMENT
+#       takeAll: CMStandard
+#       entries:
+#       - id: CMHandsInsulated
+#       - id: CMHeadsetCommand #TODO Change to ce headset
+#       - id: CMBeltUtilityFilled
+#       - id: CMBootsBlack
+#       - id: ClothingEyesGlassesMeson #TODO change to CM13 engi goggles.
+#     - name: UNIFORM
+#       choices: { CMUniform: 1 }
+#       entries:
+#       - id: CMJumpsuitChiefEngineer
+#       - id: CMJumpsuitBO
+#     - name: HELMET
+#       choices: { CMHelmet: 1 }
+#       entries:
+#       #- id: RMCHeadBeretEngineering #TODO ADD
+#       - id: RMCHardhatWhite
+#       - id: CMHeadCap
+#       #- id: CMHeadWeldingHelmet #TODO ADD
+#     - name: SUIT
+#       choices: { CMSuit: 1 }
+#       entries:
+#       #- id: RMCSuitBlackHazard #TODO ADD
+#       #- id: RMCSuitBlueHazard #TODO ADD
+#       #- id: RMCSuitOrangekHazard #TODO ADD
+#       #- id: RMCSuitYellowHazard #TODO ADD
+#       - id: CMCoatOfficer
+#     - name: BACKPACK
+#       choices: { CMBackpack: 1 }
+#       entries:
+#       - id: CMSatchel
+#       - id: CMSatchelMarineTech
+#       - id: RMCSatchelWelder
+#       - id: CMBackpackWelder
+#       #- id: RMCWelderpack #TODO ADD
+#     - name: POUCHES
+#       choices: { CMPouches: 2 }
+#       entries:
+#       - id: RMCPouchFirstAidInjectors
+#       - id: RMCPouchFirstAidSplintsGauzeOintment
+#       - id: RMCPouchFirstAidPills
+#       - id: RMCPouchGeneralLarge
+#       - id: RMCPouchToolsFill
+#       - id: RMCPouchConstruction
+#       - id: RMCPouchElectronicsFill
+#       - id: RMCPouchMagazine
+#       - id: RMCPouchShotgun
+#       - id: RMCPouchPistol
+#       - id: RMCPouchFlareFilled
+#       #- id: RMCPouchFuelTank
+#     - name: PERSONAL SIDEARM
+#       choices: { CMWeapon: 1 }
+#       entries:
+#       - id: CMWeaponPistolMK80
+#       - id: CMWeaponPistolM1984
+#       - id: RMCWeaponRevolverM44
+#     - name: ACCESSORIES
+#       choices: { CMAccessories: 1 }
+#       entries:
+#       - id: CMWebbingBrown
+#       - id: CMWebbingBlack
+#       - id: CMWebbingPouch
+#       - id: CMWebbing
+#       #- id: CMWebbingHolster # TODO RMC14 Shoulder Holster Webbing
+#     - name: DEPLOYENT GEAR
+#     - name: COMBAT EQUIPMENT
+#       takeAll: CMStandard
+#       entries:
+#       - id: CMArmorM3Medium #ToDo Replace with officer M3
+#       - id: CMBootsBlackFilled
+#       - id: RMCLaserDesignator
+#     - name: COMBAT HELMET
+#       choices: { CMCombatHelmet: 1 }
+#       entries:
+#       #- id: CMArmorHelmetM10Officer #ToDo Add.
+#       - id: CMArmorHelmetM10Tech
+#     - name: MASK
+#       choices: { CMMask: 1 }
+#       entries:
+#       - id: CMMaskGas
+#       - id: CMMaskCoif
+#     - name: PRIMARY FIREARMS
+#       choices: { CMWeaponPrimary: 1 }
+#       entries:
+#       - id: WeaponShotgunM42A2
+#       #- id: WeaponPulseRifle #ToDo Add.
+#       #- id: WeaponIncineratorUnit #ToDo Add.
+#     - name: Spare Equipment
+#       entries:
+#       - id: CMHeadsetEngineer
+#         ammount: 15
+
+
+#   - type: CMAutomatedVendor
+#     jobs:
+#     - CMQuartermaster
+#     sections:
+#     - name: STANDARD EQUIPMENT
+#       takeAll: CMStandard
+#       entries:
+#       - id: CMHandsInsulated
+#       - id: CMJumpsuitQM
+#       - id: CMHeadsetQM #Todo: Fix comms access squads.
+#       - id: CMSatchel
+#       #- id: CMCoatQM #Todo: Port this
+#     - name: Headgear
+#       choices: { CMHelmet: 1 }
+#       entries:
+#       - id: CMHeadCapQM
+#       - id: CMHeadBeret
+#       - id: CMHeadCapCargo
+#     - name: PERSONAL SIDEARM
+#       choices: { CMWeapon: 1 }
+#       entries:
+#       - id: CMWeaponPistolMK80
+#       - id: CMWeaponPistolM1984
+#       - id: RMCWeaponRevolverM44
+#     - name: COMBAT EQUIPMENT
+#       takeAll: CMStandard
+#       entries:
+#       - id: CMArmorM3Medium #ToDo Replace with officer M3
+#       - id: CMBootsBlackFilled
+#       - id: ArmorHelmetM10
+#     - name: POUCHES
+#       choices: { CMPouches: 2 }
+#       entries:
+#       - id: RMCPouchFirstAidInjectors
+#       - id: RMCPouchFirstAidSplintsGauzeOintment
+#       - id: RMCPouchFirstAidPills
+#       - id: RMCPouchGeneralLarge
+#       - id: RMCPouchTools
+#       - id: RMCPouchConstruction
+#     - name: ACCESSORIES
+#       choices: { CMAccessories: 1 }
+#       entries:
+#       - id: CMWebbingBrown
+#       - id: CMWebbingBlack
+#       - id: CMWebbing
+#     - name: Spare Equipment
+#       entries:
+#       - id: CMStampApproved
+#         ammount: 15
+
+
+#   - type: CMAutomatedVendor
+#     jobs:
+#     - CMCMO
+#     sections:
+#     - name: Medical Set (Mandatory)
+#       takeAll: CMMedicalSet
+#       entries:
+#       - id: CMVendorBundleCrewMedicalEssentialsNurse
+#     - name: STANDARD EQUIPMENT
+#       entries:
+#       - id: CMHandsLatex
+#       - id: CMHeadsetCMO
+#     - name: EYEWEAR
+#       choices: { CMEyewear: 1 }
+#       - id: RMCGlassesMedicalHUDGlasses
+#       #- id: RMCGlassesMedicalHUDGlassesPrescription
+#       #- id: RMCGlasesReagentScannerHUD
+#       #- id: RMCGlasesReagentScannerHUDPrescription
+#     - name: Uniform # TODO: Port this.
+#       choices: { CMUniform: 1 }
+#       entries:
+#       - id: CMJumpsuitCMO
+#         recommended: true
+#       - id: RMCScrubsLightBlue
+#       - id: CMScrubsGreen
+#       - id: CMScrubsBlue
+#       - id: CMScrubsPurple
+#       - id: CMScrubsOrange
+#       - id: RMCScrubsOlive
+#       - id: RMCScrubsGrey
+#     - name: SUIT
+#       choices: { CMSuit: 1 }
+#       entries:
+#       - id: RMCSuitLabcoat
+#         recommended: true
+#       - id: RMCSuitMedicalApron
+#     - name: Combat Equipment
+#       takeAll: CMEquipment
+#       entries:
+#       #- id: RMCCoatSnowcoat
+#       #- id: RMCMaskBalaclava
+#       #- id: RMCMaskSnowScarf
+#     - name: HEADWEAR
+#       choices: { CMHelmet: 1 }
+#       entries:
+#       #- id: RMCCMOPeakedCap
+#       - id: CMHeadCapSurgOrange
+#       - id: CMHeadCapSurgBlue
+#       - id: CMHeadCapSurgPurple
+#       - id: CMHeadCapSurgGreen
+#     - name: BAG
+#       choices: { CMBag: 1 }
+#       entries:
+#       - id: CMSatchelMarine
+#       - id: CMBackpackMarine
+#       - id: CMSatchelMedical
+#         recommended: true
+#       - id: CMBackpackMedical
+#         recommended: true
+#     - name: BELT
+#       choices: { CMBelt: 1 }
+#       entries:
+#       - id: CMBeltMedicBagFilled
+#       - id: CMBeltMedicalFilled
+#     - name: PERSONAL SIDEARM
+#       choices: { CMWeapon: 1 }
+#       entries:
+#       - id: CMWeaponPistolMK80
+#       - id: CMWeaponPistolM1984
+#       - id: RMCWeaponRevolverM44
+#     - name: COMBAT EQUIPMENT (COMBAT USE ONLY)
+#       takeAll: CMStandard
+#       entries:
+#       - id: CMArmorM3Medium #ToDo Replace with officer M3
+#       - id: CMBootsBlackFilled
+#       - id: ArmorHelmetM10
+#     - name: Pouches
+#       choices: { CMPouches: 2 }
+#       entries:
+#       - id: RMCPouchAutoinjector
+#       - id: RMCPouchFirstAidInjectors
+#       - id: RMCPouchFirstAidSplintsGauzeOintment
+#       - id: RMCPouchFirstAidPills
+#       - id: RMCPouchFirstResponder
+#       - id: RMCPouchMedical
+#       - id: RMCPouchMedkit
+#       # Add pressuized reagent pouch.
+#       - id: RMCPouchGeneralLarge
+#       #- id: RMCPouchSling
+#     - name: Accessories
+#       choices: { CMAccessories: 1 }
+#       entries:
+#       - id: CMWebbingBrown
+#       - id: CMWebbingBlack
+#       - id: CMWebbing
+
+
+#   - type: CMAutomatedVendor
+#     jobs:
+#     - CMAuxiliarySupportOfficer
+#     sections:
+#     - name: STANDARD EQUIPMENT
+#       takeAll: CMStandard
+#       entries:
+#       - id: CMHandsInsulated
+#       - id: CMJumpsuitBO
+#       - id: CMHeadsetSeniorCommand
+#       - id: CMCoatASO
+#     - name: BAG
+#       choices: { CMHelmet: 1 }
+#       entries:
+#       - id: CMSatchelMarineTech
+#       - id: CMSatchel
+#     - name: PERSONAL SIDEARM
+#       choices: { CMWeapon: 1 }
+#       entries:
+#       - id: CMWeaponPistolMK80
+#       - id: CMWeaponPistolM1984
+#       - id: RMCWeaponRevolverM44
+#     - name: Headgear
+#       choices: { CMHelmet: 1 }
+#       entries:
+#       - id: RMCHeadBeretGreen
+#       - id: CMHeadBeretTan
+#       - id: CMHeadCap
+#       - id: CMHeadCapPeakedService
+#     - name: COMBAT EQUIPMENT
+#       takeAll: CMStandard
+#       entries:
+#       - id: CMArmorM3Medium #ToDo Replace with officer M3
+#       - id: CMBootsBlackFilled
+#       - id: ArmorHelmetM10
+#     - name: POUCHES
+#       choices: { CMPouches: 2 }
+#       entries:
+#       - id: RMCPouchDocument
+#       - id: RMCPouchFirstAidInjectors
+#       - id: RMCPouchFirstAidSplintsGauzeOintment
+#       - id: RMCPouchFirstAidPills
+#       - id: RMCPouchGeneralLarge
+#       - id: RMCPouchTools
+#       - id: RMCPouchConstruction
+#       #- id: RMCPouchSling
+#     - name: ACCESSORIES
+#       choices: { CMAccessories: 1 }
+#       entries:
+#       - id: CMWebbingBrown
+#       - id: CMWebbingBlack
+#       - id: CMWebbing

--- a/commanding_officer.yml
+++ b/commanding_officer.yml
@@ -1,0 +1,100 @@
+﻿- type: job
+  parent: CMJobBase
+  id: CMCommandingOfficer
+  name: cm-job-name-commanding-officer
+  description: cm-job-description-commanding-officer
+  playTimeTracker: CMJobCommandingOfficer
+  requirements:
+  - !type:DepartmentTimeRequirement
+    department: CMSquad
+    time: 54000 # 15 hours
+  - !type:TotalJobsTimeRequirement
+    group: CMJobsEngineering
+    time: 36000 # 10 hours
+  - !type:DepartmentTimeRequirement
+    department: CMMilitaryPolice
+    time: 36000 # 10 hours
+  - !type:TotalJobsTimeRequirement
+    group: CMJobsMedical
+    time: 36000 # 10 hours
+  - !type:DepartmentTimeRequirement
+    department: CMCommand
+    time: 36000 # 10 hours
+  - !type:RoleTimeRequirement
+    role: CMJobExecutiveOfficer
+    time: 36000 #10 hrs
+  weight: 10
+  startingGear: CMGearCommandingOfficer
+  icon: "CMJobIconCommandingOfficer"
+  requireAdminNotify: true
+  joinNotifyCrew: true
+  supervisors: cm-job-supervisors-marine-high-command
+  whitelisted: true
+  accessGroups:
+  - ShipMasterAccess
+  minimapIcon:
+    sprite: _RMC14/Interface/map_blips.rsi
+    state: co
+  minimapBackground:
+   sprite: _RMC14/Interface/map_blips.rsi
+   state: background_command
+  roleWeight: 0.25
+  special:
+  - !type:AddComponentSpecial
+    components:
+    - type: Skills
+      skills:
+        RMCSkillCqc: 2
+        RMCSkillConstruction: 2
+        RMCSkillFirearms: 1
+        RMCSkillFireman: 2
+        RMCSkillEndurance: 2
+        RMCSkillEngineer: 2
+        RMCSkillExecution: 1
+        RMCSkillIntel: 2
+        RMCSkillJtac: 4
+        RMCSkillLeadership: 3
+        RMCSkillMedical: 3
+        RMCSkillNavigations: 1
+        RMCSkillOverwatch: 1
+        RMCSkillPolice: 2
+        RMCSkillPowerLoader: 2
+        RMCSkillSmartGun: 1
+        RMCSkillSurgery: 1
+        RMCSkillVehicles: 1
+    - type: MarineOrders
+    - type: CMVendorUser
+      points: 120
+    - type: RMCPointing
+    - type: JobPrefix
+      prefix: "CO"
+
+- type: startingGear
+  id: CMGearCommandingOfficer
+  equipment:
+    jumpsuit: CMJumpsuitBO
+    back: CMSatchel
+    shoes: CMShoesLaceupCommander
+    head: CMHeadBeretCO
+    outerClothing: RMCCoatService
+    id: CMIDCardCommandingOfficer
+    ears: CMHeadsetSeniorCommand
+    pocket1: RMCPouchCommand
+    pocket2: RMCPouchGeneralLarge
+
+- type: entity
+  parent: CMSpawnPointJobBase
+  id: CMSpawnPointCommandingOfficer
+  name: commanding officer spawn point
+  components:
+  - type: SpawnPoint
+    job_id: CMCommandingOfficer
+  - type: Sprite
+    layers:
+    - sprite: Markers/jobs.rsi
+      state: green
+    - state: commanding_officer
+
+- type: playTimeTracker
+  id: CMJobCommandingOfficer
+  isHumanoid: true


### PR DESCRIPTION
Adds the CO's Desert Eagle, HI and HIAP .50 cal magazines, and moves the filled Mateba and Deagle holster to the CO weapon vender to allow COs the choice of sidearm they wish to have.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the CO's Deagle, Moved CO secondary belts to the CO weapon vender?
## Why / Balance
 CO has been missing their 2nd legendary sidearm from CM13, this adds it in.

## Technical details
As said in "about the PR", New belt, Deagle added, moved Mateba belt off of round start CO to the vender.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: CO's Desert Eagle
- add: .50 AE rounds for HI and HIAP
- tweaked: Location of the Mateba
- add: Mateba and Deagle belt to the CO vender
- add: Deagle Belt